### PR TITLE
Feat: Persist view mode in localStorage

### DIFF
--- a/templates/src/contexts/ViewModeContext.tsx
+++ b/templates/src/contexts/ViewModeContext.tsx
@@ -1,4 +1,4 @@
-import  { createContext, useState, useContext, ReactNode } from 'react';
+import { createContext, useState, useContext, ReactNode, useEffect } from 'react';
 
 interface ViewModeContextType {
   isDeveloperMode: boolean;
@@ -8,10 +8,17 @@ interface ViewModeContextType {
 const ViewModeContext = createContext<ViewModeContextType | undefined>(undefined);
 
 export const ViewModeProvider = ({ children }: { children: ReactNode }) => {
-  const [isDeveloperMode, setIsDeveloperMode] = useState(false); // Default to User View
+  const [isDeveloperMode, setIsDeveloperMode] = useState(() => {
+    const storedMode = localStorage.getItem('isDeveloperMode');
+    return storedMode ? JSON.parse(storedMode) : false; // Default to User View
+  });
+
+  useEffect(() => {
+    localStorage.setItem('isDeveloperMode', JSON.stringify(isDeveloperMode));
+  }, [isDeveloperMode]);
 
   const toggleViewMode = () => {
-    setIsDeveloperMode(prevMode => !prevMode);
+    setIsDeveloperMode((prevMode: boolean) => !prevMode);
   };
 
   return (


### PR DESCRIPTION
This change modifies the ViewModeProvider to store the user's view mode preference (Developer Mode or User Mode) in localStorage.

- When the application loads, it checks localStorage for a saved preference and initializes the mode accordingly.
- When the user toggles the view mode, the new preference is saved to localStorage.